### PR TITLE
8.0 product taxes group

### DIFF
--- a/product_taxes_group/model/product_template.py
+++ b/product_taxes_group/model/product_template.py
@@ -95,5 +95,5 @@ class ProductTemplate(models.Model):
             supplier_tax_ids = [x.id for x in self.sudo().supplier_taxes_id]
             customer_tax_ids = [x.id for x in self.sudo().taxes_id]
             tg_id = tg_obj.find_or_create(
-                [self.company_id.id, customer_tax_ids, supplier_tax_ids])
+                self.company_id.id, customer_tax_ids, supplier_tax_ids)
             super(ProductTemplate, self.sudo()).write({'tax_group_id': tg_id})

--- a/product_taxes_group/model/product_template.py
+++ b/product_taxes_group/model/product_template.py
@@ -81,9 +81,9 @@ class ProductTemplate(models.Model):
             # update or replace 'taxes_id' and 'supplier_taxes_id'
             tax_vals = {
                 'supplier_taxes_id': [[6, 0, [
-                    x.id for x in self.tax_group_id.supplier_tax_ids]]],
+                    x.id for x in self.sudo().tax_group_id.supplier_tax_ids]]],
                 'taxes_id': [[6, 0, [
-                    x.id for x in self.tax_group_id.customer_tax_ids]]],
+                    x.id for x in self.sudo().tax_group_id.customer_tax_ids]]],
                 }
             super(ProductTemplate, self.sudo()).write(tax_vals)
         elif 'supplier_taxes_id' in vals.keys() or 'taxes_id' in vals.keys():

--- a/product_taxes_group/model/product_template.py
+++ b/product_taxes_group/model/product_template.py
@@ -33,7 +33,6 @@ class ProductTemplate(models.Model):
     # Field Section
     tax_group_id = fields.Many2one(
         'tax.group', string='Taxes Group',
-        domain="[('company_id', '=', company_id)]",
         help="Specify the combination of taxes for this product."
         " This field is required. If you dont find the correct Tax"
         " Group, Please create a new one or ask to your account"
@@ -42,13 +41,15 @@ class ProductTemplate(models.Model):
     # Overload Section
     @api.model
     def create(self, vals):
-        self.check_coherent_vals(False, vals)
-        return super(ProductTemplate, self).create(vals)
+        res = super(ProductTemplate, self).create(vals)
+        res.check_coherent_vals(vals)
+        return res
 
     @api.multi
     def write(self, vals):
-        self.check_coherent_vals([x.id for x in self], vals)
-        return super(ProductTemplate, self).write(vals)
+        super(ProductTemplate, self).write(vals)
+        self.check_coherent_vals(vals)
+        return True
 
     # View Section
     def fields_view_get(
@@ -71,49 +72,29 @@ class ProductTemplate(models.Model):
         return res
 
     # Custom Section
-    def check_coherent_vals(self, ids, vals):
+    def check_coherent_vals(self, vals):
         """If tax group is defined, set the according taxes to the product(s);
         Otherwise, find the correct tax group, depending of the taxes, or
         create a new one, if no one are found.
         """
-        tg_obj = self.env['tax.group']
         if vals.get('tax_group_id', False):
             # update or replace 'taxes_id' and 'supplier_taxes_id'
-            tg = tg_obj.browse(vals['tax_group_id'])
-            vals['supplier_taxes_id'] = [[6, 0, [
-                x.id for x in tg.supplier_tax_ids]]]
-            vals['taxes_id'] = [[6, 0, [
-                x.id for x in tg.customer_tax_ids]]]
+            tax_vals = {
+                'supplier_taxes_id': [[6, 0, [
+                    x.id for x in self.tax_group_id.supplier_tax_ids]]],
+                'taxes_id': [[6, 0, [
+                    x.id for x in self.tax_group_id.customer_tax_ids]]],
+                }
+            self.sudo().write(tax_vals)
         elif 'supplier_taxes_id' in vals.keys() or 'taxes_id' in vals.keys():
-            if not ids:
-                # product template creation mode
-                company_id = vals.get('company_id', False)
-                if 'supplier_taxes_id' in vals.keys():
-                    supplier_tax_ids = vals['supplier_taxes_id'][0][2]
-                else:
-                    supplier_tax_ids = []
-                if 'taxes_id' in vals.keys():
-                    customer_tax_ids = vals['taxes_id'][0][2]
-                else:
-                    customer_tax_ids = []
-            else:
-                # product template Single update mode
-                if len(ids) != 1:
-                    raise ValidationError(
-                        _("You cannot change Taxes for many Products."))
-                pt = self.browse(ids)[0]
-                company_id = vals.get('company_id', False) or \
-                    pt.company_id.id
-                if (vals.get('supplier_taxes_id', False) and
-                        isinstance(vals.get('supplier_taxes_id')[0], list)):
-                    supplier_tax_ids = vals.get('supplier_taxes_id')[0][2]
-                else:
-                    supplier_tax_ids = [x.id for x in pt.supplier_taxes_id]
-                if (vals.get('taxes_id', False) and
-                        isinstance(vals.get('taxes_id')[0], list)):
-                    customer_tax_ids = vals.get('taxes_id')[0][2]
-                else:
-                    customer_tax_ids = [x.id for x in pt.taxes_id]
+            # product template Single update mode
+            tg_obj = self.env['tax.group']
+            if len(self) != 1:
+                raise ValidationError(
+                    _("You cannot change Taxes for many Products."))
+            tmpl = self.sudo().browse()
+            supplier_tax_ids = [x.id for x in tmpl.supplier_taxes_id]
+            customer_tax_ids = [x.id for x in tmpl.taxes_id]
             tg_id = tg_obj.find_or_create(
-                [company_id, customer_tax_ids, supplier_tax_ids])
-            vals['tax_group_id'] = tg_id
+                [self.company_id.id, customer_tax_ids, supplier_tax_ids])
+            tmpl.write({'tax_group_id': tg_id})

--- a/product_taxes_group/model/product_template.py
+++ b/product_taxes_group/model/product_template.py
@@ -85,16 +85,15 @@ class ProductTemplate(models.Model):
                 'taxes_id': [[6, 0, [
                     x.id for x in self.tax_group_id.customer_tax_ids]]],
                 }
-            self.sudo().write(tax_vals)
+            super(ProductTemplate, self.sudo()).write(tax_vals)
         elif 'supplier_taxes_id' in vals.keys() or 'taxes_id' in vals.keys():
             # product template Single update mode
             tg_obj = self.env['tax.group']
             if len(self) != 1:
                 raise ValidationError(
                     _("You cannot change Taxes for many Products."))
-            tmpl = self.sudo().browse()
             supplier_tax_ids = [x.id for x in tmpl.supplier_taxes_id]
             customer_tax_ids = [x.id for x in tmpl.taxes_id]
             tg_id = tg_obj.find_or_create(
                 [self.company_id.id, customer_tax_ids, supplier_tax_ids])
-            tmpl.write({'tax_group_id': tg_id})
+            super(ProductTemplate, tmpl.sudo()).write({'tax_group_id': tg_id})

--- a/product_taxes_group/model/product_template.py
+++ b/product_taxes_group/model/product_template.py
@@ -92,8 +92,8 @@ class ProductTemplate(models.Model):
             if len(self) != 1:
                 raise ValidationError(
                     _("You cannot change Taxes for many Products."))
-            supplier_tax_ids = [x.id for x in tmpl.supplier_taxes_id]
-            customer_tax_ids = [x.id for x in tmpl.taxes_id]
+            supplier_tax_ids = [x.id for x in self.sudo().supplier_taxes_id]
+            customer_tax_ids = [x.id for x in self.sudo().taxes_id]
             tg_id = tg_obj.find_or_create(
                 [self.company_id.id, customer_tax_ids, supplier_tax_ids])
-            super(ProductTemplate, tmpl.sudo()).write({'tax_group_id': tg_id})
+            super(ProductTemplate, self.sudo()).write({'tax_group_id': tg_id})

--- a/product_taxes_group/model/tax_group.py
+++ b/product_taxes_group/model/tax_group.py
@@ -109,7 +109,7 @@ class TaxGroup(models.Model):
         return super(TaxGroup, self).unlink()
 
     # Custom Sections
-    @api.multi
+    @api.model
     def find_or_create(self, company_id, customer_tax_ids, supplier_tax_ids):
         at_obj = self.env['account.tax']
         # Search for existing Taxes Group

--- a/product_taxes_group/model/tax_group.py
+++ b/product_taxes_group/model/tax_group.py
@@ -109,52 +109,56 @@ class TaxGroup(models.Model):
         return super(TaxGroup, self).unlink()
 
     # Custom Sections
-    def find_or_create(self, cr, uid, values, context=None):
-        at_obj = self.pool['account.tax']
+    @api.multi
+    def find_or_create(self, company_id, customer_tax_ids, supplier_tax_ids):
+        at_obj = self.env['account.tax']
         # Search for existing Taxes Group
-        tg_ids = self.search(
-            cr, uid, ['|', ('active', '=', False), ('active', '=', True)],
-            context=context)
-        for tg in self.browse(cr, uid, tg_ids, context=context):
-            if (tg.company_id.id == values[0] and
-                sorted([x.id for x in tg.customer_tax_ids]) == values[1] and
-                    sorted([x.id for x in tg.supplier_tax_ids]) == values[2]):
+
+        tgs = self.search([
+            '|',
+            ('active', '=', False),
+            ('active', '=', True)
+            ])
+        for tg in tgs:
+            if (tg.company_id.id == company_id
+                and sorted(tg.customer_tax_ids.ids) == sorted(customer_tax_ids)
+                and sorted(tg.supplier_tax_ids.ids) == supplier_tax_ids):
                 return tg.id
 
         # create new Taxes Group if not found
-        if len(values[1]) == 0 and len(values[2]) == 0:
+        if len(customer_tax_ids) == 0 and len(supplier_tax_ids) == 0:
             name = _('No taxes')
-        elif len(values[2]) == 0:
+        elif len(supplier_tax_ids) == 0:
             name = _('No Purchase Taxes - Customer Taxes: ')
-            for tax in at_obj.browse(cr, uid, values[1]):
+            for tax in at_obj.browse(customer_tax_ids):
                 name += tax.description and tax.description or tax.name
                 name += ' + '
             name = name[:-3]
-        elif len(values[1]) == 0:
+        elif len(customer_tax_ids) == 0:
             name = _('Purchase Taxes: ')
-            for tax in at_obj.browse(cr, uid, values[2], context=None):
+            for tax in at_obj.browse(supplier_tax_ids):
                 name += tax.description and tax.description or tax.name
                 name += ' + '
             name = name[:-3]
             name += _('- No Customer Taxes')
         else:
             name = _('Purchase Taxes: ')
-            for tax in at_obj.browse(cr, uid, values[2], context=None):
+            for tax in at_obj.browse(supplier_tax_ids):
                 name += tax.description and tax.description or tax.name
                 name += ' + '
             name = name[:-3]
             name += _(' - Customer Taxes: ')
-            for tax in at_obj.browse(cr, uid, values[1], context=None):
+            for tax in at_obj.browse(customer_tax_ids):
                 name += tax.description and tax.description or tax.name
                 name += ' + '
             name = name[:-3]
         name = name[:self._MAX_LENGTH_NAME] \
             if len(name) > self._MAX_LENGTH_NAME else name
-        return self.create(cr, uid, {
+        return self.create({
             'name': name,
-            'company_id': values[0],
-            'customer_tax_ids': [(6, 0, values[1])],
-            'supplier_tax_ids': [(6, 0, values[2])]}, context=context)
+            'company_id': company_id,
+            'customer_tax_ids': [(6, 0, customer_tax_ids)],
+            'supplier_tax_ids': [(6, 0, supplier_tax_ids)]}).id
 
     def init(self, cr):
         """Generate Taxes Groups for each combinations of Taxes Group set
@@ -183,15 +187,15 @@ class TaxGroup(models.Model):
         # Associate product template to existing or new taxes group
         for pt in pt_list:
             counter += 1
-            res = [
+            args = [
                 pt.company_id and pt.company_id.id or False,
                 sorted([x.id for x in pt.taxes_id]),
                 sorted([x.id for x in pt.supplier_taxes_id])]
-            if res not in list_res.values():
+            if args not in list_res.values():
                 _logger.info(
                     """create new Taxes Group. Product templates"""
                     """ managed %s/%s""" % (counter, total))
-                tg_id = self.find_or_create(cr, uid, res)
+                tg_id = self.find_or_create(cr, uid, *args)
                 list_res[tg_id] = res
                 # associate product template to the new Taxes Group
                 pt_obj.write(cr, uid, [pt.id], {'tax_group_id': tg_id})

--- a/product_taxes_group/model/tax_group.py
+++ b/product_taxes_group/model/tax_group.py
@@ -77,14 +77,12 @@ class TaxGroup(models.Model):
     supplier_tax_ids = fields.Many2many(
         'account.tax', 'product_supplier_tax_rel',
         'group_id', 'tax_id', string='Supplier Taxes', domain="""[
-            ('company_id', '=', company_id),
             ('parent_id', '=', False),
             ('type_tax_use', 'in', ['purchase', 'all'])]""")
 
     customer_tax_ids = fields.Many2many(
         'account.tax', 'product_customer_tax_rel',
         'group_id', 'tax_id', string='Customer Taxes', domain="""[
-            ('company_id', '=', company_id),
             ('parent_id', '=', False),
             ('type_tax_use', 'in', ['sale', 'all'])]""")
 

--- a/product_taxes_group/model/tax_group.py
+++ b/product_taxes_group/model/tax_group.py
@@ -120,9 +120,13 @@ class TaxGroup(models.Model):
             ('active', '=', True)
             ])
         for tg in tgs:
-            if (tg.company_id.id == company_id
-                and sorted(tg.customer_tax_ids.ids) == sorted(customer_tax_ids)
-                and sorted(tg.supplier_tax_ids.ids) == supplier_tax_ids):
+            if (
+                    tg.company_id.id == company_id
+                    and sorted(tg.customer_tax_ids.ids) ==
+                    sorted(customer_tax_ids)
+                    and sorted(tg.supplier_tax_ids.ids) ==
+                    sorted(supplier_tax_ids)
+                    ):
                 return tg.id
 
         # create new Taxes Group if not found
@@ -196,11 +200,11 @@ class TaxGroup(models.Model):
                     """create new Taxes Group. Product templates"""
                     """ managed %s/%s""" % (counter, total))
                 tg_id = self.find_or_create(cr, uid, *args)
-                list_res[tg_id] = res
+                list_res[tg_id] = args
                 # associate product template to the new Taxes Group
                 pt_obj.write(cr, uid, [pt.id], {'tax_group_id': tg_id})
             else:
                 # associate product template to existing Taxes Group
                 pt_obj.write(cr, uid, [pt.id], {
                     'tax_group_id': list_res.keys()[
-                        list_res.values().index(res)]})
+                        list_res.values().index(args)]})

--- a/product_taxes_group/security/ir_model_access.yml
+++ b/product_taxes_group/security/ir_model_access.yml
@@ -21,7 +21,7 @@
 ##############################################################################
 
 -  !record {model: ir.model.access, id: ir_model_access_tax_group_reader}:
-    group_id: account.group_account_invoice
+    group_id: base.group_user
     model_id: model_tax_group
     name: Taxes Group Reader
     perm_read: true


### PR DESCRIPTION
Hi Sylvain.
I propose some change so the module can be used in multi-company case.
The main behaviour I need is to share configuration between company.
For exemple, if you have 20 FR company in the same DB, you want to share the same tax configuration. So when I set a tax group on a product the taxe of all company must be set on the product. As only the tax of the company are visible (due to security rule) you need to use sudo to write the tax on the product. When we read it we use the current right as we only want to get the taxes of our company.
